### PR TITLE
[86bxm1je2][UI] Load image for Image Component from the inspector panel 

### DIFF
--- a/Engine/Source/ImageComponent.cpp
+++ b/Engine/Source/ImageComponent.cpp
@@ -20,13 +20,13 @@ ImageComponent::ImageComponent(GameObject* owner, bool active) : Component(owner
 }
 
 ImageComponent::ImageComponent(GameObject* owner) : Component(owner, ComponentType::IMAGE) {
-	//mImage = Importer::Texture::Load("Assets/Textures/CesiumLogoFlat.png", 630045728);
-	mImage = ( ResourceTexture *) App->GetResource()->RequestResource(818189439, Resource::Type::Texture);
-
+    SetImage(mResourceId);
 }
 
 ImageComponent:: ~ImageComponent() {
 }
+
+
 
 void ImageComponent::Draw(bool useOrthographicProjection) const
 {
@@ -87,4 +87,8 @@ void ImageComponent::Save(Archive& archive) const
 
 void ImageComponent::LoadFromJSON(const rapidjson::Value& data, GameObject* owner)
 {
+}
+
+void ImageComponent::SetImage(unsigned int resourceId) {
+    mImage = (ResourceTexture*)App->GetResource()->RequestResource(resourceId, Resource::Type::Texture);
 }

--- a/Engine/Source/ImageComponent.cpp
+++ b/Engine/Source/ImageComponent.cpp
@@ -22,6 +22,7 @@ ImageComponent::ImageComponent(GameObject* owner, bool active) : Component(owner
 ImageComponent::ImageComponent(GameObject* owner) : Component(owner, ComponentType::IMAGE) {
 	//mImage = Importer::Texture::Load("Assets/Textures/CesiumLogoFlat.png", 630045728);
 	mImage = ( ResourceTexture *) App->GetResource()->RequestResource(818189439, Resource::Type::Texture);
+
 }
 
 ImageComponent:: ~ImageComponent() {

--- a/Engine/Source/ImageComponent.h
+++ b/Engine/Source/ImageComponent.h
@@ -17,6 +17,12 @@ public:
 
     void Draw(bool useOrthographicProjection) const;
 
+    void SetImage(ResourceTexture* image) { mImage = image; }
+    unsigned int GetResourceId() const { return mResourceId; }
+    ResourceTexture* GetImage() const { return mImage; }
+
+    void SetImage(unsigned int resourceId);
+
 private:
     void Save(Archive& archive) const override;
     void LoadFromJSON(const rapidjson::Value& data, GameObject* owner) override;
@@ -24,4 +30,5 @@ private:
     ResourceTexture* mImage;
     float4 mColor;
     unsigned int texId = 0;
+    unsigned int mResourceId = 818189439; // Temporary default image - Just a simple square made of four squares (Red, Green, Blue, White) 
 };

--- a/Engine/Source/InspectorPanel.cpp
+++ b/Engine/Source/InspectorPanel.cpp
@@ -18,6 +18,8 @@
 #include "MathFunc.h"
 
 #include "ResourceMaterial.h"
+#include "ResourceTexture.h"
+
 
 InspectorPanel::InspectorPanel() : Panel(INSPECTORPANEL, true) {}
 
@@ -468,10 +470,20 @@ void InspectorPanel::DrawCameraComponent(CameraComponent* component)
 	// Is culling
 }
 
-void InspectorPanel::DrawImageComponent(ImageComponent* component) {
+void InspectorPanel::DrawImageComponent(ImageComponent* imageComponent) {
+	static int resourceId = int(imageComponent->GetResourceId());
+
+	//TODO: Handle the case where the resource is not found
+	ImGui::Text("Resource Id: "); ImGui::SameLine(); ImGui::InputInt("", &resourceId, 0); ImGui::SameLine();
+	if (ImGui::Button("Load"))
+	{
+		imageComponent->SetImage(resourceId);
+	}
+
+	//TODO: Decide what information to display 
+	ImGui::Text("Width:%dpx", imageComponent->GetImage()->GetWidth()); ImGui::SameLine(); ImGui::Text("Height:%dpx", imageComponent->GetImage()->GetHeight());
 
 }
 
-void InspectorPanel::DrawCanvasComponent(CanvasComponent* component) {
-
+void InspectorPanel::DrawCanvasComponent(CanvasComponent* imageComponent) {
 }

--- a/Engine/Source/InspectorPanel.h
+++ b/Engine/Source/InspectorPanel.h
@@ -33,8 +33,8 @@ private:
 	void DrawPointLightComponent(PointLightComponent* component);
 	void DrawSpotLightComponent(SpotLightComponent* component);
 	void DrawMeshRendererComponent(MeshRendererComponent* component);
-	void DrawImageComponent(ImageComponent* component);
-	void DrawCanvasComponent(CanvasComponent* component);
+	void DrawImageComponent(ImageComponent* imageComponent);
+	void DrawCanvasComponent(CanvasComponent* imageComponent);
 	void DragAndDropSource(Component* component);
 	void DragAndDropTarget(GameObject* object, Component* target);
 	void MaterialVariables(MeshRendererComponent* renderComponent);


### PR DESCRIPTION
We are adding support to load texture resources by its id within the inspector panel for the image component. We are also displaying the image width and height.