### PR TITLE
Setting Panel FPS Limit & VSync issues solved

### DIFF
--- a/Engine/Game/config.txt
+++ b/Engine/Game/config.txt
@@ -7,108 +7,108 @@ Draw Grid: 1
 15
 About##
 0
-720 410
+700 420
 32 35
 Console##
 1
-660 935
-995 155
+640 925
+1035 155
 Debug
 0
-898 499
+878 509
 333 287
 Editor Controls##
 1
-865 369
-790 76
+845 379
+830 76
 Hierarchy##
 1
-660 369
-203 564
+640 379
+203 544
 Inspector##
 1
-1657 369
-243 721
+1677 379
+243 701
 TagsManagerPanel##
 0
-720 410
+700 420
 32 35
 NavMesh Parameters
 0
-721 410
+701 420
 599 423
 Resource##
 1
-660 935
-995 155
+640 925
+1035 155
 LightningPanel##
 0
-720 410
+700 420
 32 35
 Scene##
 1
-865 447
-790 486
+845 457
+830 466
 Pause##
 1
-865 369
-790 76
+845 379
+830 76
 Project##
 1
-660 935
-995 155
+640 925
+1035 155
 Timer##
-0
-722 410
+1
+1340 504
 448 405
 Settings##
 1
-723 532
+852 578
 287 357
 [Window][DockSpaceViewport_11111111]
 Pos=0,19
-Size=1240,721
+Size=1280,701
 Collapsed=0
 
 [Window][Console##]
-Pos=0,585
-Size=995,155
+Pos=0,565
+Size=1035,155
 Collapsed=0
 DockId=0x00000002,0
 
 [Window][Hierarchy##]
 Pos=0,19
-Size=203,564
+Size=203,544
 Collapsed=0
 DockId=0x00000005,0
 
 [Window][Inspector##]
-Pos=997,19
-Size=243,721
+Pos=1037,19
+Size=243,701
 Collapsed=0
 DockId=0x00000004,0
 
 [Window][Resource##]
-Pos=0,585
-Size=995,155
+Pos=0,565
+Size=1035,155
 Collapsed=0
 DockId=0x00000002,2
 
 [Window][Scene##]
 Pos=205,97
-Size=790,486
+Size=830,466
 Collapsed=0
 DockId=0x00000008,0
 
 [Window][Pause##]
 Pos=205,19
-Size=790,76
+Size=830,76
 Collapsed=0
 DockId=0x00000007,0
 
 [Window][Project##]
-Pos=0,585
-Size=995,155
+Pos=0,565
+Size=1035,155
 Collapsed=0
 DockId=0x00000002,1
 
@@ -118,7 +118,7 @@ Size=400,400
 Collapsed=0
 
 [Window][Settings##]
-Pos=63,182
+Pos=212,218
 Size=287,357
 Collapsed=0
 
@@ -143,13 +143,13 @@ Size=32,35
 Collapsed=0
 
 [Window][Timer##]
-Pos=62,60
+Pos=700,144
 Size=448,405
 Collapsed=0
 
 [Window][Editor Controls##]
 Pos=205,19
-Size=790,76
+Size=830,76
 Collapsed=0
 DockId=0x00000007,1
 
@@ -174,7 +174,7 @@ Size=212,94
 Collapsed=0
 
 [Docking][Data]
-DockSpace         ID=0x8B93E3BD Window=0xA787BDB4 Pos=660,369 Size=1240,721 Split=X
+DockSpace         ID=0x8B93E3BD Window=0xA787BDB4 Pos=640,379 Size=1280,701 Split=X
   DockNode        ID=0x00000003 Parent=0x8B93E3BD SizeRef=995,721 Split=Y
     DockNode      ID=0x00000001 Parent=0x00000003 SizeRef=1240,564 Split=X
       DockNode    ID=0x00000005 Parent=0x00000001 SizeRef=203,564 Selected=0xF8AAC790

--- a/Engine/Game/config.txt
+++ b/Engine/Game/config.txt
@@ -7,108 +7,108 @@ Draw Grid: 1
 15
 About##
 0
-700 420
+720 410
 32 35
 Console##
 1
-640 925
-1035 155
+660 935
+995 155
 Debug
 0
-878 509
+898 499
 333 287
 Editor Controls##
 1
-845 379
-830 76
+865 369
+790 76
 Hierarchy##
 1
-640 379
-203 544
+660 369
+203 564
 Inspector##
 1
-1677 379
-243 701
+1657 369
+243 721
 TagsManagerPanel##
 0
-700 420
+720 410
 32 35
 NavMesh Parameters
 0
-701 420
+721 410
 599 423
 Resource##
 1
-640 925
-1035 155
+660 935
+995 155
 LightningPanel##
 0
-700 420
+720 410
 32 35
 Scene##
 1
-845 457
-830 466
+865 447
+790 486
 Pause##
 1
-845 379
-830 76
+865 369
+790 76
 Project##
 1
-640 925
-1035 155
+660 935
+995 155
 Timer##
-1
-1340 504
+0
+722 410
 448 405
 Settings##
 1
-852 578
+723 532
 287 357
 [Window][DockSpaceViewport_11111111]
 Pos=0,19
-Size=1280,701
+Size=1240,721
 Collapsed=0
 
 [Window][Console##]
-Pos=0,565
-Size=1035,155
+Pos=0,585
+Size=995,155
 Collapsed=0
 DockId=0x00000002,0
 
 [Window][Hierarchy##]
 Pos=0,19
-Size=203,544
+Size=203,564
 Collapsed=0
 DockId=0x00000005,0
 
 [Window][Inspector##]
-Pos=1037,19
-Size=243,701
+Pos=997,19
+Size=243,721
 Collapsed=0
 DockId=0x00000004,0
 
 [Window][Resource##]
-Pos=0,565
-Size=1035,155
+Pos=0,585
+Size=995,155
 Collapsed=0
 DockId=0x00000002,2
 
 [Window][Scene##]
 Pos=205,97
-Size=830,466
+Size=790,486
 Collapsed=0
 DockId=0x00000008,0
 
 [Window][Pause##]
 Pos=205,19
-Size=830,76
+Size=790,76
 Collapsed=0
 DockId=0x00000007,0
 
 [Window][Project##]
-Pos=0,565
-Size=1035,155
+Pos=0,585
+Size=995,155
 Collapsed=0
 DockId=0x00000002,1
 
@@ -118,7 +118,7 @@ Size=400,400
 Collapsed=0
 
 [Window][Settings##]
-Pos=212,218
+Pos=63,182
 Size=287,357
 Collapsed=0
 
@@ -143,13 +143,13 @@ Size=32,35
 Collapsed=0
 
 [Window][Timer##]
-Pos=700,144
+Pos=62,60
 Size=448,405
 Collapsed=0
 
 [Window][Editor Controls##]
 Pos=205,19
-Size=830,76
+Size=790,76
 Collapsed=0
 DockId=0x00000007,1
 
@@ -174,7 +174,7 @@ Size=212,94
 Collapsed=0
 
 [Docking][Data]
-DockSpace         ID=0x8B93E3BD Window=0xA787BDB4 Pos=640,379 Size=1280,701 Split=X
+DockSpace         ID=0x8B93E3BD Window=0xA787BDB4 Pos=660,369 Size=1240,721 Split=X
   DockNode        ID=0x00000003 Parent=0x8B93E3BD SizeRef=995,721 Split=Y
     DockNode      ID=0x00000001 Parent=0x00000003 SizeRef=1240,564 Split=X
       DockNode    ID=0x00000005 Parent=0x00000001 SizeRef=203,564 Selected=0xF8AAC790

--- a/Engine/Source/SettingsPanel.cpp
+++ b/Engine/Source/SettingsPanel.cpp
@@ -31,6 +31,8 @@ void SettingsPanel::Draw(int windowFlags)
 		mCulling = App->GetScene()->GetApplyFrustumCulling();
 		mEngineVsyncEnabled = App->GetEngineClock()->GetVsyncStatus();
 		mGameVsyncEnabled = App->GetGameClock()->GetVsyncStatus();
+		mEngineFpsLimitEnabled = App->GetEngineClock()->IsFpsLimitEnabled();
+		mGameFpsLimitEnabled = App->GetGameClock()->IsFpsLimitEnabled();
 		mEngineFpsLimit = App->GetEngineClock()->GetFpsLimit();
 		mGameFpsLimit = App->GetGameClock()->GetFpsLimit();
 		mGrid = App->GetDebugDraw()->GetShouldRenderGrid();
@@ -53,15 +55,21 @@ void SettingsPanel::Draw(int windowFlags)
 			ImGui::BeginDisabled();
 		}
 
-		ImGui::Checkbox("Enable FPS Limit##1", &mEngineFpsLimitEnabled);
-		mEngineFpsLimit = App->GetEngineClock()->GetFpsLimit();
-		ImGui::SliderInt("FPS Limit##1", &mEngineFpsLimit, 10, 240);
+		if (ImGui::Checkbox("Enable FPS Limit##1", &mEngineFpsLimitEnabled))
+		{
+			App->GetEngineClock()->EnableFpsLimit(mEngineFpsLimitEnabled);
+		}
+
+		if (ImGui::SliderInt("FPS Limit##1", &mEngineFpsLimit, 10, 240))
+		{
+			App->GetEngineClock()->SetFpsLimit(mEngineFpsLimit);
+		}
+		
 		if (mEngineVsyncEnabled) 
 		{
 			ImGui::EndDisabled();
 		}
 
-		App->GetEngineClock()->SetFpsLimit(mEngineFpsLimit);
 		ImGui::Spacing();
 		ImGui::SeparatorText("Game");
 		ImGui::Checkbox("Game Vsync enabled", &mGameVsyncEnabled);
@@ -75,14 +83,21 @@ void SettingsPanel::Draw(int windowFlags)
 			ImGui::BeginDisabled();
 		}
 
-		ImGui::Checkbox("Enable FPS Limit##2", &mGameFpsLimitEnabled);
-		ImGui::SliderInt("FPS Limit##2", &mGameFpsLimit, 10, 240);
+		if (ImGui::Checkbox("Enable FPS Limit##2", &mGameFpsLimitEnabled))
+		{
+			App->GetGameClock()->EnableFpsLimit(mGameFpsLimitEnabled);
+		}
+
+		if (ImGui::SliderInt("FPS Limit##2", &mGameFpsLimit, 10, 240))
+		{
+			App->GetGameClock()->SetFpsLimit(mGameFpsLimit);
+		}
+
 		if (mGameVsyncEnabled) 
 		{
 			ImGui::EndDisabled();
 		}
 
-		App->GetGameClock()->SetFpsLimit(mGameFpsLimit);
 		ImGui::Unindent();
 
 		ImGui::SeparatorText("Editor settings");

--- a/Engine/Source/SettingsPanel.h
+++ b/Engine/Source/SettingsPanel.h
@@ -12,7 +12,7 @@
 struct WindowState 
 {
 	std::string name;
-	bool IsOpen;
+	bool IsOpen = false;
 	ImVec2 position;
 	ImVec2 size;
 };

--- a/Engine/Source/Timer.cpp
+++ b/Engine/Source/Timer.cpp
@@ -25,8 +25,8 @@ void Timer::Update()
 		mDeltaTime = ReadDelta(); 
 	}
 
-	//Delay the frame so the FPS match the limit if mDeltaTime if  vsync isn't enabled
-	if (!mEnabledVsync && (mFpsLimit > 0 && mDeltaTime / mSpeed < (MILLI_IN_SECONDS / mFpsLimit)))
+	//Delay the frame so the FPS match the limit if mDeltaTime if vsync isn't enabled
+	if (!mEnabledVsync && mFpsLimitEnabled && (mDeltaTime / mSpeed < (MILLI_IN_SECONDS / mFpsLimit)))
 	{
 		mFrameDelay = (MILLI_IN_SECONDS / mFpsLimit) - mDeltaTime / mSpeed;
 

--- a/Engine/Source/Timer.cpp
+++ b/Engine/Source/Timer.cpp
@@ -1,13 +1,16 @@
 #include "Timer.h"
+#include "Application.h"
 #include "SDL.h"
 
 
-void Timer::Start() {
+void Timer::Start() 
+{
 	mLastReadTime = SDL_GetTicks();
 	SetTimeScale(1.f);
 }
 
-void Timer::StartWithRunTime() {
+void Timer::StartWithRunTime() 
+{
 	mLastReadTime = SDL_GetTicks();
 	mTotalTime = mLastReadTime;
 }
@@ -17,11 +20,13 @@ void Timer::Update()
 	++mUpdateFrames;
 	++mTotalFrames;
 
-	if (mChangeSpeed) {
+	if (mChangeSpeed) 
+	{
 		mDeltaTime = SetSpeed(mNewSpeed);
 		mChangeSpeed = false;
 	}
-	else { 
+	else 
+	{ 
 		mDeltaTime = ReadDelta(); 
 	}
 
@@ -42,12 +47,14 @@ void Timer::Update()
 	}
 
 	//Checks if the frame is the slowest of all (doesn't check the first 50 because the first ones are always very slow)
-	if (mTotalFrames > 50) {
+	if (mTotalFrames > 50) 
+	{
 		SetSlowestFrame();
 	}
 
 	//Logs the frames' time 
-	if (mMsLog.size() >= 100) {
+	if (mMsLog.size() >= 100) 
+	{
 		mMsLog.erase(mMsLog.begin());
 	}
 	mMsLog.push_back(mDeltaTime / mSpeed);
@@ -55,8 +62,10 @@ void Timer::Update()
 	mUpdateTime += mDeltaTime / mSpeed;
 
 	//Logs the average FPS every half a second
-	if (mUpdateTime > 0.5f * MILLI_IN_SECONDS) {
-		if (mFpsLog.size() >= 100) {
+	if (mUpdateTime > 0.5f * MILLI_IN_SECONDS) 
+	{
+		if (mFpsLog.size() >= 100) 
+		{
 			mFpsLog.erase(mFpsLog.begin());
 		}
 		mFpsLog.push_back(mUpdateFrames * MILLI_IN_SECONDS / mUpdateTime);
@@ -69,14 +78,18 @@ void Timer::Update()
 
 		mUpdateFpsLog = true;
 	}
+
+	if(App->GetCurrentClock() == this ) SDL_GL_SetSwapInterval(mEnabledVsync ? 1 : 0);
 }
 
-long Timer::Read() {
+long Timer::Read() 
+{
 	ReadDelta();
 	return mTotalTime;
 }
 
-long Timer::ReadDelta() {
+long Timer::ReadDelta() 
+{
 	Uint32 newTime = SDL_GetTicks();
 	Uint32 elapsedTime = newTime - mLastReadTime;
 	mLastReadTime = newTime;
@@ -86,7 +99,8 @@ long Timer::ReadDelta() {
 	return convertedTime;
 }
 
-void Timer::ResetVariables() {
+void Timer::ResetVariables() 
+{
 	mLastReadTime = 0;
 
 	mDeltaTime = 0;
@@ -117,16 +131,19 @@ void Timer::ResetVariables() {
 	mSlowestFrame = 0;
 }
 
-void Timer::Pause() { 
+void Timer::Pause() 
+{ 
 	SetTimeScale(0.f); 
 }
 
-void Timer::Resume() {
+void Timer::Resume() 
+{
 	SetTimeScale(1.f);
 	mDeltaTime = ReadDelta();
 }
 
-long Timer::Stop() {
+long Timer::Stop() 
+{
 	Uint32 finalTime = Read();
 
 	//We reset all variables
@@ -137,32 +154,38 @@ long Timer::Stop() {
 	return finalTime;
 }
 
-long Timer::SetSpeed(float speed) {
+long Timer::SetSpeed(float speed) 
+{
 	long currentTime = ReadDelta();
 	mSpeed = speed;
 	return currentTime;
 }
 
-void Timer::SetTimeScale(float speed) {
+void Timer::SetTimeScale(float speed) 
+{
 	mNewSpeed = speed;
 	mChangeSpeed = true;
 }
 
-void Timer::SetSlowestFrame() {
-	if (mDeltaTime > mSlowestFrameTime) {
+void Timer::SetSlowestFrame() 
+{
+	if (mDeltaTime > mSlowestFrameTime) 
+	{
 		mSlowestFrameTime = mDeltaTime;
 		mSlowestFrame = mTotalFrames;
 	}
 }
 
-void Timer::SetLowestFps() {
-	if (mFpsLog.back() < mLowestFps) {
+void Timer::SetLowestFps() 
+{
+	if (mFpsLog.back() < mLowestFps) 
+	{
 		mLowestFps = mFpsLog.back();
 		mLowestFpsTime = mRealTime;
 	}
 }
 
-void Timer::SetVsyncStatus(bool vsyncStatus) {
+void Timer::SetVsyncStatus(bool vsyncStatus) 
+{
 	mEnabledVsync = vsyncStatus;
-	SDL_GL_SetSwapInterval(mEnabledVsync ? 1 : 0);
 }

--- a/Engine/Source/Timer.h
+++ b/Engine/Source/Timer.h
@@ -40,6 +40,8 @@ public:
     unsigned int GetTotalFrames() const { return mTotalFrames; }
     void SetTotalFrames(unsigned int gameFrames) { mTotalFrames += gameFrames; }    //Adds the frames of the game execution to the total frames of the engine
 
+    bool IsFpsLimitEnabled() const { return mFpsLimitEnabled; }
+    void EnableFpsLimit(bool enable) { mFpsLimitEnabled = enable; }
     unsigned int GetFpsLimit() const { return mFpsLimit; }
     void SetFpsLimit(unsigned int limit) { mFpsLimit = limit; }
 
@@ -77,6 +79,7 @@ private:
 
     unsigned long mDeltaTime = 0;   //Time of the last frame
 
+    bool mFpsLimitEnabled = true;
     unsigned int mFpsLimit = 60;    //Limit of FPS
 
     float mUpdateTime = 0;           //Time since last FPS calculation (reset every 500 ms)


### PR DESCRIPTION
The FPS Limit button in the settings panel now works correctly when disabled, letting the timer have as many fps as it can.
Also, VSync is turned on and off separately between the Engine and Game timers.