### PR TITLE
Settings panel saving system fixed

### DIFF
--- a/Engine/Source/SettingsPanel.cpp
+++ b/Engine/Source/SettingsPanel.cpp
@@ -202,6 +202,8 @@ void SettingsPanel::LoadSettings()
 			mGrid = std::stoi(line.substr(line.find(":") + 1));
 		}
 
+		std::vector<const char*> panelNames = App->GetEditor()->GetPanelNames();
+
 		// Load the windows state
 		if (std::getline(in_file, line))
 		{
@@ -223,12 +225,14 @@ void SettingsPanel::LoadSettings()
 					std::istringstream iss(line);
 					iss >> windowState->size.x >> windowState->size.y;
 				}
-				const char* panelName = App->GetEditor()->GetPanelNames().at(i);
-				if (windowState->name == panelName && windowState->IsOpen)
+				if (i < panelNames.size()) 
 				{
-					App->GetEditor()->GetPanel(panelName)->Open();
+					const char* panelName = panelNames.at(i);
+					if (windowState->name == panelName && windowState->IsOpen)
+					{
+						App->GetEditor()->GetPanel(panelName)->Open();
+					}
 				}
-
 				mOpenedWindowsInfo.push_back(windowState);
 			}
 		}

--- a/Engine/Source/SettingsPanel.cpp
+++ b/Engine/Source/SettingsPanel.cpp
@@ -225,20 +225,16 @@ void SettingsPanel::LoadSettings()
 					std::istringstream iss(line);
 					iss >> windowState->size.x >> windowState->size.y;
 				}
-				bool panelExists = std::find(panelNames.begin(), panelNames.end(), windowState->name) != panelNames.end();
+				auto it = std::find(panelNames.begin(), panelNames.end(), windowState->name);
+				bool panelExists = it != panelNames.end();
 				if (panelExists)
 				{
-					const char* panelName = *std::find(panelNames.begin(), panelNames.end(), windowState->name);
+					const char* panelName = *it;
 					if (windowState->name == panelName && windowState->IsOpen)
 					{
 						App->GetEditor()->GetPanel(panelName)->Open();
 					}
 					mOpenedWindowsInfo.push_back(windowState);
-					LOG("Panel %s found", windowState->name.c_str())
-				}
-				else
-				{
-					LOG("Panel %s not found", windowState->name.c_str())
 				}
 			}
 		}

--- a/Engine/Source/SettingsPanel.cpp
+++ b/Engine/Source/SettingsPanel.cpp
@@ -225,15 +225,21 @@ void SettingsPanel::LoadSettings()
 					std::istringstream iss(line);
 					iss >> windowState->size.x >> windowState->size.y;
 				}
-				if (i < panelNames.size()) 
+				bool panelExists = std::find(panelNames.begin(), panelNames.end(), windowState->name) != panelNames.end();
+				if (panelExists)
 				{
-					const char* panelName = panelNames.at(i);
+					const char* panelName = *std::find(panelNames.begin(), panelNames.end(), windowState->name);
 					if (windowState->name == panelName && windowState->IsOpen)
 					{
 						App->GetEditor()->GetPanel(panelName)->Open();
 					}
+					mOpenedWindowsInfo.push_back(windowState);
+					LOG("Panel %s found", windowState->name.c_str())
 				}
-				mOpenedWindowsInfo.push_back(windowState);
+				else
+				{
+					LOG("Panel %s not found", windowState->name.c_str())
+				}
 			}
 		}
 


### PR DESCRIPTION
Now you can add or remove panels in the ModuleEditor without having problems when loading the config.txt.