### PR TITLE
Dangerous bug with prefabs

### DIFF
--- a/Engine/Source/ModuleScene.cpp
+++ b/Engine/Source/ModuleScene.cpp
@@ -487,11 +487,14 @@ GameObject* ModuleScene::LoadPrefab(const char* saveFilePath, bool update, GameO
 
 void ModuleScene::OpenPrefabScreen(const char* saveFilePath)
 {
-	if (mBackgroundScene != nullptr) 
-	{ 
-		mClosePrefab = true; 
+	if (mBackgroundScene != nullptr)
+	{
+		mClosePrefab = true;
 	}
-	mPrefabPath = saveFilePath;
+	else
+	{
+		mPrefabPath = saveFilePath;
+	}
 }
 
 void ModuleScene::ClosePrefabScreen()


### PR DESCRIPTION
Bug: If you open a predab while editing another prefab, the late is overriden by the former.

Fixed by closing the prefab editor when the user opens another prefab. 