### PR TITLE
[Gamepad] Pause menu fixes

### DIFF
--- a/Engine/Scripting/DashState.cpp
+++ b/Engine/Scripting/DashState.cpp
@@ -88,6 +88,7 @@ StateType DashState::HandleInput()
 
 void DashState::Update()
 {
+    if (GameManager::GetInstance()->IsPaused()) return;
 
     float dashSpeed = mPlayerController->GetDashRange() / mPlayerController->GetDashDuration();
     float3 currentPos = mPlayerController->GetPlayerPosition();

--- a/Engine/Scripting/HudController.cpp
+++ b/Engine/Scripting/HudController.cpp
@@ -88,6 +88,7 @@ void HudController::Start()
             mContinueBtn->AddEventHandler(EventType::CLICK, new std::function<void()>(std::bind(&HudController::OnContinueBtnClick, this)));
             mContinueBtn->AddEventHandler(EventType::HOVER, new std::function<void()>(std::bind(&HudController::OnContinueBtnHoverOn, this)));
             mContinueBtn->AddEventHandler(EventType::HOVEROFF, new std::function<void()>(std::bind(&HudController::OnContinueBtnHoverOff, this)));
+            OnContinueBtnHoverOn();
         }
         if (mOptionsBtnGO)
         {


### PR DESCRIPTION
We are fixing a bug causing the player to perform a dash when leaving the pause using the gamepad (Button A). We 're also setting the "Continue" option as default when entering the pause menu.