### PR TITLE
fix audio memory leak

### DIFF
--- a/Engine/Source/ModuleAudio.cpp
+++ b/Engine/Source/ModuleAudio.cpp
@@ -258,7 +258,7 @@ FMOD::Channel* ModuleAudio::Play(const std::string& fileName)
 	FMOD::Sound* sound = nullptr;
 	FMOD::Channel* channel = nullptr;
 
-	FMOD_RESULT result = mCoreSystem->createSound(fileName.c_str(), FMOD_DEFAULT, nullptr, &sound);
+	FMOD_RESULT result = mCoreSystem->createStream(fileName.c_str(), FMOD_DEFAULT, nullptr, &sound);
 	CheckError(result);
 
 	// Play the sound on a new channel
@@ -281,7 +281,7 @@ FMOD::Channel* ModuleAudio::PlayOneShot(const std::string& fileName)
 	FMOD::Channel* channel = nullptr; 
 
 	// Create the sound using the FMOD system
-	FMOD_RESULT result = mCoreSystem->createSound(fileName.c_str(), FMOD_DEFAULT, nullptr, &sound);
+	FMOD_RESULT result = mCoreSystem->createStream(fileName.c_str(), FMOD_DEFAULT, nullptr, &sound);
 	CheckError(result);
 	sound->set3DMinMaxDistance(5.0f, 30.0f);
 

--- a/Engine/Source/ModuleAudio.cpp
+++ b/Engine/Source/ModuleAudio.cpp
@@ -300,7 +300,8 @@ void ModuleAudio::Release(FMOD::Channel* channel)
 
 	if (sound)
 	{
-		sound->release();  // Release the sound when playback ends
+		channel->stop();
+		sound->release();
 	}
 }
 


### PR DESCRIPTION
Basically, 

- `createSound `loads the music into memory for multiple uses
- `createStream `loads the music from the hard drive, which is slower

However, I did not take this characteristic into account, I repeatedly loaded the same music into memory, leading to memory leaks and failing to utilize the benefits of createSound.

Tthere's no time to redesign, just switch to createStream.