### PR TITLE
Video Fixes

### DIFF
--- a/Engine/Source/VideoComponent.cpp
+++ b/Engine/Source/VideoComponent.cpp
@@ -133,7 +133,7 @@ void VideoComponent::Stop()
 {
 	Pause();
 	RestartVideo();
-	ReadNextFrame();
+	//ReadNextFrame();
 	mFirstFrame = true;
 }
 

--- a/Engine/Source/VideoComponent.cpp
+++ b/Engine/Source/VideoComponent.cpp
@@ -46,13 +46,20 @@ Component* VideoComponent::Clone(GameObject* owner) const
 
 void VideoComponent::Update()
 {
-	if (mIsPlaying)
+	if (!mFirstFrame)
 	{
-		mElapsedTime += App->GetDt();
-		while (mElapsedTime > mFrameTime)
+		if (mIsPlaying)
 		{
-			ReadNextFrame();
+			mElapsedTime += App->GetDt();
+			while (mElapsedTime > mFrameTime)
+			{
+				ReadNextFrame();
+			}
 		}
+	}
+	else
+	{
+		mFirstFrame = false;
 	}
 }
 
@@ -127,6 +134,7 @@ void VideoComponent::Stop()
 	Pause();
 	RestartVideo();
 	ReadNextFrame();
+	mFirstFrame = true;
 }
 
 void VideoComponent::Reset()
@@ -318,6 +326,7 @@ void VideoComponent::RestartVideo()
 	mFrameTime = 0.0;
 	av_seek_frame(mFormatContext, mVideoStreamIndex, 0, AVSEEK_FLAG_BACKWARD);
 	avcodec_flush_buffers(mCodecContext);
+	mFirstFrame = true;
 }
 
 void VideoComponent::ReadNextFrame()

--- a/Engine/Source/VideoComponent.h
+++ b/Engine/Source/VideoComponent.h
@@ -75,6 +75,7 @@ private:
 
 	bool mIsPlaying = false;
 	bool mLoop = false;
+	bool mFirstFrame = true;
 
 	unsigned int mTextureID = 0;
 	unsigned int mUIProgramID = 0;


### PR DESCRIPTION
- The end of the video now do not shows the first frame
- At the start of the video, VideoComponent waits one frame to start the video to avoid Start() frame long delta times.