### PR TITLE
Movement locked before Victory screen

### DIFF
--- a/Engine/Scripting/GameManager.cpp
+++ b/Engine/Scripting/GameManager.cpp
@@ -220,7 +220,7 @@ void GameManager::SetActiveBattleArea(BattleArea* activeArea)
 
 void GameManager::Victory()
 {
-    mPaused = true;
+    //mPaused = true;
 
     mHudController->SetScreen(SCREEN::WIN, true);
 

--- a/Engine/Scripting/HudController.cpp
+++ b/Engine/Scripting/HudController.cpp
@@ -475,6 +475,7 @@ void HudController::WinUpdate()
     {
         if (mFinalVideoComponent && !mIsFinalVideoPlaying)
         {
+            GameManager::GetInstance()->SetPaused(true, false);
             mFinalVideoGO->SetEnabled(true);
             mFinalVideoComponent->Play();
             PlayVideoAssociatedAudio(mFinalVideoComponent->GetName());


### PR DESCRIPTION
When triggering the Victory screen, the player won't lose control until the cinematic starts playing